### PR TITLE
feat: Adding helm to run `helmChartInflationGenerator`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 # build stage
 FROM golang:1 AS build
 
+LABEL maintainer="Sam Clark <sam@followsound.co.uk>"
+LABEL org.opencontainers.image.source = "https://github.com/followsound/argocd-voodoobox-plugin"
+LABEL org.opencontainers.image.description = "An Argo CD plugin to decrypt strongbox encrypted files and build Kubernetes resources"
+
 ENV \
   STRONGBOX_VERSION=1.0.1 \
-  KUSTOMIZE_VERSION=v4.5.5
+  KUSTOMIZE_VERSION=v4.5.5 \
+  HELM_VERSION=v3.11.0
 
 RUN os=$(go env GOOS) && arch=$(go env GOARCH) \
   && curl -Ls https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_${os}_${arch}.tar.gz \
@@ -11,7 +16,11 @@ RUN os=$(go env GOOS) && arch=$(go env GOARCH) \
   && chmod +x /usr/local/bin/kustomize \
   && curl -Ls https://github.com/uw-labs/strongbox/releases/download/v${STRONGBOX_VERSION}/strongbox_${STRONGBOX_VERSION}_${os}_${arch} \
     > /usr/local/bin/strongbox \
-  && chmod +x  /usr/local/bin/strongbox
+  && chmod +x  /usr/local/bin/strongbox \
+  && curl -O https://get.helm.sh/helm-${HELM_VERSION}-${os}-${arch}.tar.gz \
+  && tar -xf helm-${HELM_VERSION}-${os}-${arch}.tar.gz \
+  && cp ${os}-${arch}/helm /usr/local/bin/helm \
+  && chmod +x /usr/local/bin/helm
 
 ADD . /app
 
@@ -33,13 +42,14 @@ RUN groupadd -g $ARGOCD_USER_ID argocd && \
     useradd -r -u $ARGOCD_USER_ID -g argocd argocd && \
     apt-get update && \
     apt-get -y upgrade && \
-    apt-get install -y git git-lfs && \
+  apt-get install -y git git-lfs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=build \
   /usr/local/bin/kustomize \
   /usr/local/bin/strongbox \
+  /usr/local/bin/helm \
   /argocd-voodoobox-plugin \
   /usr/local/bin/
 

--- a/generate.go
+++ b/generate.go
@@ -85,7 +85,7 @@ func hasSSHRemoteBaseURL(kFiles []string) (bool, error) {
 
 // runKustomizeBuild will run `kustomize build` cmd and return generated yaml or error
 func runKustomizeBuild(ctx context.Context, cwd string, env []string) (string, error) {
-	k := exec.CommandContext(ctx, "kustomize", "build", ".")
+	k := exec.CommandContext(ctx, "kustomize", "build", ".", "--enable-helm")
 
 	k.Dir = cwd
 	k.Env = env

--- a/generate_test.go
+++ b/generate_test.go
@@ -14,6 +14,7 @@ func Test_hasSSHRemoteBaseURL(t *testing.T) {
 	}{
 		{"with remote base", args{"./testData/app-with-remote-base"}, true, false},
 		{"without remote base", args{"./testData/app-with-secrets"}, false, false},
+		{"with helm base", args{"./testData/app-with-helm"}, false, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/testData/app-with-helm/kustomization.yaml
+++ b/testData/app-with-helm/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmChartInflationGenerator:
+- chartName: gitlab-runner
+  chartRepoUrl: https://charts.gitlab.io
+  releaseName: gitlab-runner
+  chartVersion: v0.36.0


### PR DESCRIPTION
I use `helmChartInflationGenerator` a lot so adding this compatibility to avoid having to rewrite all my deployments.

Also, there isn't good support for external helm files in ArgoCD yet (https://github.com/argoproj/argo-cd/issues/938)